### PR TITLE
Added es-lint sniff to fab polish

### DIFF
--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -132,6 +132,6 @@ def composer_validate():
 
 
 @sniff(severity='major', timing='fast')
-def eslint():
+def run_eslint():
     info('Running ESLint:')
     return local("! ./node_modules/eslint/bin/eslint.js .")

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -134,4 +134,4 @@ def composer_validate():
 @sniff(severity='major', timing='fast')
 def run_eslint():
     info('Running ESLint:')
-    return local("! ./node_modules/eslint/bin/eslint.js .")
+    return local("./node_modules/eslint/bin/eslint.js .")

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -133,5 +133,5 @@ def composer_validate():
 
 @sniff(severity='major', timing='fast')
 def run_eslint():
-    info('Running ESLint:')
+    info('Running ESLint...')
     return local("./node_modules/eslint/bin/eslint.js .")

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -134,4 +134,4 @@ def composer_validate():
 @sniff(severity='major', timing='fast')
 def eslint():
     info('Running ESLint:')
-    return local("! ./node_modules/eslint/bin/eslint.js app/assets/javascripts/src/*")
+    return local("! ./node_modules/eslint/bin/eslint.js .")

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -134,4 +134,8 @@ def composer_validate():
 @sniff(severity='major', timing='fast')
 def run_eslint():
     info('Running ESLint...')
-    return local("./node_modules/eslint/bin/eslint.js .")
+    return local(
+        "git ls-files | "
+        "grep '\.js$' | "
+        "xargs ./node_modules/eslint/bin/eslint.js"
+    )

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -129,3 +129,9 @@ def check_image_edited():
 def composer_validate():
     info('Running composer validate...')
     return local('composer validate')
+
+
+@sniff(severity='major', timing='fast')
+def eslint():
+    info('Running ESLint:')
+    return local("! ./node_modules/eslint/bin/eslint.js app/assets/javascripts/src/*")


### PR DESCRIPTION
We need to allow users to run an `eslint` command to check the state of javascript coding standards in their respective repos through a CI system.

A sniff to make this possible has been added in this PR
