### PR TITLE
Eslint sniff now uses a target config file instead of a default config

### DIFF
--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -146,7 +146,7 @@ def run_eslint():
     return local(
         "git ls-files | "
         "grep '\.js$' | "
-        "xargs ./node_modules/eslint/bin/eslint.js"
+        "xargs ./node_modules/eslint/bin/eslint.js --config '.eslintrc_travis'"
     )
 
 

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -146,7 +146,7 @@ def run_eslint():
     return local(
         "git ls-files | "
         "grep '\.js$' | "
-        "xargs ./node_modules/eslint/bin/eslint.js --config '.eslintrc_travis'"
+        "xargs ./node_modules/eslint/bin/eslint.js --config './.eslintrc_travis'"
     )
 
 


### PR DESCRIPTION
Eslint sniff now uses a target config file instead of a default config
