### PR TITLE
Add timings for sniff

### DIFF
--- a/fabpolish/__init__.py
+++ b/fabpolish/__init__.py
@@ -104,7 +104,7 @@ def polish(env='dev'):
         for sniff in sniffs_to_run:
             t_start = time()
             results.append(sniff['function']())
-            print sniff['function'].name, 'took', (time() - t_start), 'ms'
+            print sniff['function'].name, 'took', (time() - t_start), 's'
 
     if any(result.failed for result in results):
         sys.exit(1)

--- a/fabpolish/__init__.py
+++ b/fabpolish/__init__.py
@@ -7,6 +7,8 @@ from fabric.main import list_commands
 from fabric.api import lcd, local, settings, task, puts, hide
 from fabric.colors import green
 
+from time import time
+
 import fabfile
 
 FABFILE_DIR = os.path.abspath(os.path.dirname(fabfile.__file__))
@@ -100,7 +102,9 @@ def polish(env='dev'):
         else:
             raise ValueError('env must be one of: ' + str(['dev', 'ci']))
         for sniff in sniffs_to_run:
+            t_start = time()
             results.append(sniff['function']())
+            print sniff['function'].name, 'took', (time() - t_start), 'ms'
 
     if any(result.failed for result in results):
         sys.exit(1)


### PR DESCRIPTION
Sample:

```
Finding merge conflict leftovers...
find_merge_conflict_leftovers took 0.0641739368439 s
Fixing directory permissions...
fix_directory_permission took 0.0110030174255 s
Fixing permissions for files
fix_file_permission took 0.0138289928436 s
Fixing script permissions...
fix_script_permission took 0.00948905944824 s
Fixing whitespace errors...
fix_white_space took 0.533913135529 s
Running php coding standards check...
php_coding_check took 43.3834688663 s
Checking for var_dump, echo or die statements...
check_var_dump took 0.0427129268646 s
Validating doctrine orm schema...
[Mapping]  OK - The mapping files are correct.
validate_doctrine_schema took 1.38936901093 s
Checking use of symfony 2.0 validation...
validate_symfony2 took 0.0898380279541 s
Checking outdated imports...
check_outdated_import took 0.0513300895691 s
Checking use of outdated doctrine...
check_outdated_doctrine took 0.0487239360809 s
Checking use of queue name parameters...
check_queue_parameter took 0.0198140144348 s
Checking no-servername compatibility...
servername_compatibility took 0.0477299690247 s
Checking direct use of pheanstalk...
check_pheanstalk took 0.0452170372009 s
Checking accounts dependency in tests...
check_accounts_dependency took 0.00610589981079 s
Checking use of preg_replace...
check_preg_replace took 0.0163149833679 s
Finding use of old deprecated records functions...
find_deprecated_record_func took 0.0522131919861 s
```
