### PR TITLE
Added sniff for checking composer security vulnerabilities.

### DIFF
--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -163,10 +163,10 @@ def check_preg_replace():
 def composer_security_check_symfony2():
     """Requires sensio/distribution-bundle = v3.0.* """
     info('Running security check for composer dependencies...')
-    return local("php bin/console security:check")
+    return local("php app/console security:check")
 
 
 @sniff(severity='major', timing='fast')
 def composer_security_check_symfony3():
     info('Running security check for composer dependencies...')
-    return local("php app/console security:check")  
+    return local("php bin/console security:check")  

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -160,8 +160,13 @@ def check_preg_replace():
 
 
 @sniff(severity='major', timing='fast')
-def composer_security_check():
+def composer_security_check_symfony2():
+    """Requires sensio/distribution-bundle = v3.0.* """
     info('Running security check for composer dependencies...')
-    return local(
-        "php bin/console security:check"
-    )
+    return local("php bin/console security:check")
+
+
+@sniff(severity='major', timing='fast')
+def composer_security_check_symfony3():
+    info('Running security check for composer dependencies...')
+    return local("php app/console security:check")  

--- a/fabpolish/contrib.py
+++ b/fabpolish/contrib.py
@@ -157,3 +157,11 @@ def check_preg_replace():
         "! find src -name '*.php' -print0 | "
         "xargs -0 grep -n 'preg_replace('"
     )
+
+
+@sniff(severity='major', timing='fast')
+def composer_security_check():
+    info('Running security check for composer dependencies...')
+    return local(
+        "php bin/console security:check"
+    )


### PR DESCRIPTION
What:
For checking security vulnerabilities in composer dependencies.

Why: 
SECURITY: For staying update to tackle latest vulnerabilities in dependencies. 