### PR TITLE
Feature: Add support for python3

### DIFF
--- a/fabpolish/__init__.py
+++ b/fabpolish/__init__.py
@@ -11,7 +11,7 @@ import fabfile
 
 FABFILE_DIR = os.path.abspath(os.path.dirname(fabfile.__file__))
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 
 def info(text):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='fab-polish',
-      version='1.1.0',
+      version='1.2.0',
       description='Polish git versioned source code using Fabric',
       url='https://github.com/practo/FabPolish',
       author='J Kishore Kumar',
@@ -9,6 +9,6 @@ setup(name='fab-polish',
       license='MIT',
       packages=['fabpolish'],
       install_requires=[
-          'fabric',
+          'fabric3',
       ],
       zip_safe=False)


### PR DESCRIPTION
## What?
Add python3 support in `fabpolish` by using `fabric3` rather than `fabric`.

## Why?
`fabpolish` doesn't work for `python3`